### PR TITLE
adding github action to build the docs

### DIFF
--- a/docs/.github/workflows/docs.yml
+++ b/docs/.github/workflows/docs.yml
@@ -1,0 +1,34 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+      fail-fast: false
+
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install documentation-building requirements
+        shell: bash -l {0}
+        run: |
+          set -vxeuo pipefail
+          python -m pip install sphinx
+
+    - name: Build Docs
+      shell: bash -l {0}
+      run: make -C docs/ html


### PR DESCRIPTION
If this isn't a terrible idea, please merge.

I'm using the bluesky event model as an example (https://github.com/bluesky/event-model/blob/master/.github/workflows/docs.yml), so I am following what they did instead of trying to get sphinx and travis to work together. I *think* I know what I'm doing, but really I'm trying something to see if it works.